### PR TITLE
API-7320 로그인 로직에서 불필요한 raise 구문 삭제

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,9 +7,6 @@ class UsersController < ApplicationController
     raise Exceptions::BadRequest, '아이디와 비밀번호를 확인해주세요' if user.nil?
 
     PasswordEncoder.new.decode(sign_in_params[:password], user.password_digest)
-
-  rescue ActionController::ParameterMissing
-    raise Exceptions::BadRequest, '아이디와 비밀번호를 확인해주세요'
   end
 
   def sign_up

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -8,6 +8,37 @@ RSpec.describe 'UsersController', type: :request do
 
     subject { JSON.parse(response.body) }
 
+    context '요청 파라미터인' do
+      context '이메일이 비어있다면,' do
+        let(:empty_email) do
+          {
+            email: '',
+            password: Faker::Internet.password
+          }
+        end
+        before { post '/users/sign-in', params: empty_email, headers: {} }
+
+        it '400 BadRequest 응답과 에러 메세지를 반환한다.' do
+          expect(response).to have_http_status(:bad_request)
+          expect(subject['message']).to eq '필수 파라메터가 필요합니다: email'
+        end
+      end
+      context '비밀번호가 비어있다면,' do
+        let(:empty_password) do
+          {
+            email: Faker::Internet.unique.email,
+            password: ''
+          }
+        end
+        before { post '/users/sign-in', params: empty_password, headers: {} }
+
+        it '400 BadRequest 응답과 에러 메세지를 반환한다.' do
+          expect(response).to have_http_status(:bad_request)
+          expect(subject['message']).to eq '필수 파라메터가 필요합니다: password'
+        end
+      end
+    end
+
     context '가입 이메일이 유효하지 않은 경우,' do
       let(:invalid_email) do
         {


### PR DESCRIPTION
## 작업 내용 (Content)

- 불필요한 raise ParameterMissing 구문을 삭제한다.
- ParameterMissing 케이스에 대한 로그인 검증 테스트를 추가한다.
- CC https://github.com/solomon-maeng/taxi-dispatch-api/pull/7#discussion_r993393885

## 링크 (Links)

- [JIRA 티켓 이름](https://dramancompany.atlassian.net/browse/API-)
- [API 스펙 문서](https://dramancompany.atlassian.net/wiki)
- [개발 문서](https://dramancompany.atlassian.net/wiki)
- [기획 문서](https://dramancompany.atlassian.net/wiki)
- [디자인 문서](https://dramancompany.atlassian.net/wiki)

## 기타 사항 (Etc)

- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등
- Additional information about this PR or any troubles working on this PR.

## Merge 전 필요 작업 (Checklist before merge)

- [ ] 예) XX 테이블 추가, 앱 배포 등
- [ ] eg) Create XX table, Deploy app etc

## 희망 리뷰 완료 일 (Expected due date)

`202X. X. X. Wed`