### PR TITLE
API-7321 회원가입, 로그인 테스트 코드 중복 제거

### DIFF
--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'shared_helper'
 
 RSpec.describe 'UsersController', type: :request do
   describe '#sign_in' do
@@ -18,9 +19,8 @@ RSpec.describe 'UsersController', type: :request do
         end
         before { post '/users/sign-in', params: empty_email, headers: {} }
 
-        it '400 BadRequest 응답과 에러 메세지를 반환한다.' do
-          expect(response).to have_http_status(:bad_request)
-          expect(subject['message']).to eq '필수 파라메터가 필요합니다: email'
+        it_behaves_like 'Bad Request 응답 처리', :request do
+          let(:message) { '필수 파라메터가 필요합니다: email' }
         end
       end
       context '비밀번호가 비어있다면,' do
@@ -32,9 +32,8 @@ RSpec.describe 'UsersController', type: :request do
         end
         before { post '/users/sign-in', params: empty_password, headers: {} }
 
-        it '400 BadRequest 응답과 에러 메세지를 반환한다.' do
-          expect(response).to have_http_status(:bad_request)
-          expect(subject['message']).to eq '필수 파라메터가 필요합니다: password'
+        it_behaves_like 'Bad Request 응답 처리', :request do
+          let(:message) { '필수 파라메터가 필요합니다: password' }
         end
       end
     end
@@ -48,9 +47,8 @@ RSpec.describe 'UsersController', type: :request do
       end
       before { post '/users/sign-in', params: invalid_email, headers: {} }
 
-      it '400 BadRequest 응답과 에러 메세지를 반환한다.' do
-        expect(response).to have_http_status(:bad_request)
-        expect(subject['message']).to eq '아이디와 비밀번호를 확인해주세요'
+      it_behaves_like 'Bad Request 응답 처리', :request do
+        let(:message) { '아이디와 비밀번호를 확인해주세요' }
       end
     end
 
@@ -63,9 +61,8 @@ RSpec.describe 'UsersController', type: :request do
       end
       before { post '/users/sign-in', params: invalid_password, headers: {} }
 
-      it '400 BadRequest 응답과 에러 메세지를 반환한다.' do
-        expect(response).to have_http_status(:bad_request)
-        expect(subject['message']).to eq '아이디와 비밀번호를 확인해주세요'
+      it_behaves_like 'Bad Request 응답 처리', :request do
+        let(:message) { '아이디와 비밀번호를 확인해주세요' }
       end
     end
   end
@@ -106,11 +103,11 @@ RSpec.describe 'UsersController', type: :request do
         end
         before { post '/users/sign-up', params: empty_email, headers: {} }
 
-        it '400 BadRequest 응답과 에러 메세지를 반환한다.' do
-          expect(response).to have_http_status(:bad_request)
-          expect(subject['message']).to eq '필수 파라메터가 필요합니다: email'
+        it_behaves_like 'Bad Request 응답 처리', :request do
+          let(:message) { '필수 파라메터가 필요합니다: email' }
         end
       end
+
       context '비밀번호가 비어있다면,' do
         let(:empty_password) do
           {
@@ -121,11 +118,11 @@ RSpec.describe 'UsersController', type: :request do
         end
         before { post '/users/sign-up', params: empty_password, headers: {} }
 
-        it '400 BadRequest 응답과 에러 메세지를 반환한다.' do
-          expect(response).to have_http_status(:bad_request)
-          expect(subject['message']).to eq '필수 파라메터가 필요합니다: password'
+        it_behaves_like 'Bad Request 응답 처리', :request do
+          let(:message) { '필수 파라메터가 필요합니다: password' }
         end
       end
+
       context 'user_type이 비어있다면,' do
         let(:empty_user_type) do
           {
@@ -136,9 +133,8 @@ RSpec.describe 'UsersController', type: :request do
         end
         before { post '/users/sign-up', params: empty_user_type, headers: {} }
 
-        it '400 BadRequest 응답과 에러 메세지를 반환한다.' do
-          expect(response).to have_http_status(:bad_request)
-          expect(subject['message']).to eq '필수 파라메터가 필요합니다: userType'
+        it_behaves_like 'Bad Request 응답 처리', :request do
+          let(:message) { '필수 파라메터가 필요합니다: userType' }
         end
       end
     end
@@ -153,9 +149,8 @@ RSpec.describe 'UsersController', type: :request do
       end
       before { post '/users/sign-up', params: invalid_email, headers: {} }
 
-      it '400 BadRequest 응답과 에러 메세지를 반환한다.' do
-        expect(response).to have_http_status(:bad_request)
-        expect(subject['message']).to eq '올바른 이메일을 입력해주세요'
+      it_behaves_like 'Bad Request 응답 처리', :request do
+        let(:message) { '올바른 이메일을 입력해주세요' }
       end
     end
 
@@ -169,9 +164,8 @@ RSpec.describe 'UsersController', type: :request do
       end
       before { post '/users/sign-up', params: invalid_user_type, headers: {} }
 
-      it '400 BadRequest 응답과 에러 메세지를 반환한다.' do
-        expect(response).to have_http_status(:bad_request)
-        expect(subject['message']).to eq '올바른 userType을 입력해주세요'
+      it_behaves_like 'Bad Request 응답 처리', :request do
+        let(:message) { '올바른 userType을 입력해주세요' }
       end
     end
 
@@ -185,9 +179,8 @@ RSpec.describe 'UsersController', type: :request do
       end
       before { post '/users/sign-up', params: duplicate_email, headers: {} }
 
-      it '409 Conflict 응답과 에러 메세지를 반환한다.' do
-        expect(subject['message']).to eq '이미 가입된 이메일입니다'
-        expect(response).to have_http_status(:conflict)
+      it_behaves_like 'Conflict 응답 처리', :request do
+        let(:message) { '이미 가입된 이메일입니다' }
       end
     end
   end

--- a/spec/shared/response.examples.rb
+++ b/spec/shared/response.examples.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+shared_examples 'Bad Request 응답 처리' do |request_method_name|
+  describe '응답' do
+    subject { JSON.parse(response.body) }
+
+    before { send request_method_name }
+
+    it do
+      expect(response).to have_http_status(:bad_request)
+      expect(subject['message']).to eq(message)
+    end
+  end
+end
+
+shared_examples 'Conflict 응답 처리' do |request_method_name|
+  describe '응답' do
+    subject { JSON.parse(response.body) }
+
+    before { send request_method_name }
+
+    it do
+      expect(response).to have_http_status(:conflict)
+      expect(subject['message']).to eq(message)
+    end
+  end
+end

--- a/spec/shared_helper.rb
+++ b/spec/shared_helper.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'shared/response.examples'


### PR DESCRIPTION
## 작업 내용 (Content)

- 회원가입, 로그인 테스트 코드에 있는 중복을 제거한다.
- shared_examples 구문을 사용한다.
- CC https://github.com/solomon-maeng/taxi-dispatch-api/pull/7#discussion_r993402456

## 링크 (Links)

- [JIRA 티켓 이름](https://dramancompany.atlassian.net/browse/API-)
- [API 스펙 문서](https://dramancompany.atlassian.net/wiki)
- [개발 문서](https://dramancompany.atlassian.net/wiki)
- [기획 문서](https://dramancompany.atlassian.net/wiki)
- [디자인 문서](https://dramancompany.atlassian.net/wiki)

## 기타 사항 (Etc)

- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등
- Additional information about this PR or any troubles working on this PR.

## Merge 전 필요 작업 (Checklist before merge)

- [ ] 예) XX 테이블 추가, 앱 배포 등
- [ ] eg) Create XX table, Deploy app etc

## 희망 리뷰 완료 일 (Expected due date)

`202X. X. X. Wed`