### PR TITLE
API-7326 accessToken 생성 개체 구현 및 스펙 검증

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "puma", "~> 5.0"
 gem "mysql2"
 gem "bcrypt"
 gem "ununiga"
+gem "jwt"
 
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 # gem "jbuilder"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
+    jwt (2.5.0)
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -205,6 +206,7 @@ DEPENDENCIES
   byebug
   factory_bot_rails
   faker
+  jwt
   mysql2
   puma (~> 5.0)
   rails (~> 7.0.4)

--- a/app/services/token_generator.rb
+++ b/app/services/token_generator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class TokenGenerator
+
+  def generate(payload, exp = 2.hours)
+    payload[:exp] = exp.to_i
+    JWT.encode(payload, secret_key)
+  end
+
+  private
+
+  def secret_key
+    Rails.application.secret_key_base
+  end
+end

--- a/spec/services/token_factory_spec.rb
+++ b/spec/services/token_factory_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe TokenGenerator, type: :service do
+
+  describe '토큰 생성 개체' do
+    let(:user_id) { Faker::Number.number }
+
+    it 'user_id 값을 사용하여 토큰을 생성한다.' do
+      # Arrange
+      sut = described_class.new
+
+      # Act
+      token = sut.generate(user_id:)
+
+      # Assert
+      expect(token).not_to be_nil
+      expect(token.split('.').size).to eq 3
+    end
+  end
+end


### PR DESCRIPTION
## 작업 내용 (Content)

- 사용자의 id 값을 기반으로 2시간 유지되는 accessToken 생성 개체를 구현한다.
- 이에 대응되는 형식 검증 테스트를 추가한다.

## 링크 (Links)

- [accessToken 생성 개체 구현 및 스펙 검증](https://dramancompany.atlassian.net/browse/API-7326)
- [API 스펙 문서](https://dramancompany.atlassian.net/wiki)
- [개발 문서](https://dramancompany.atlassian.net/wiki)
- [기획 문서](https://dramancompany.atlassian.net/wiki)
- [디자인 문서](https://dramancompany.atlassian.net/wiki)

## 기타 사항 (Etc)

- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등
- Additional information about this PR or any troubles working on this PR.

## Merge 전 필요 작업 (Checklist before merge)

- [ ] 예) XX 테이블 추가, 앱 배포 등
- [ ] eg) Create XX table, Deploy app etc

## 희망 리뷰 완료 일 (Expected due date)

`202X. X. X. Wed`