### PR TITLE
API-7334 인증 요청 시 잘못된 경우에 대한 검증 논리 구현 및 스펙 추가

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development, :test do
   gem 'rubocop', require: false # Ruby static code analyzer
   gem 'rubocop-rails', require: false # rubocop extensions for rails convention
   gem 'shoulda-matchers'
+  gem 'timecop'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,7 @@ GEM
     shoulda-matchers (5.2.0)
       activesupport (>= 5.2.0)
     thor (1.2.1)
+    timecop (0.9.5)
     timeout (0.3.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
@@ -214,6 +215,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   shoulda-matchers
+  timecop
   tzinfo-data
   ununiga
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,10 +55,13 @@ class ApplicationController < ActionController::API
     render json: { message: '현재 요청사항을 처리할 수 없습니다. 잠시 후 다시 시도해주세요' }, status: :internal_server_error
   end
 
+  AUTHORIZATION_HEADER = 'Authorization'
+
   private
 
   def authenticate_request
-    TokenExtractor.new.extract(request.headers['Token'])
+    token = TokenExtractor.new.extract(request.headers[AUTHORIZATION_HEADER])
+    TokenParser.new.parse(token)
   end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,4 +55,10 @@ class ApplicationController < ActionController::API
     render json: { message: '현재 요청사항을 처리할 수 없습니다. 잠시 후 다시 시도해주세요' }, status: :internal_server_error
   end
 
+  private
+
+  def authenticate_request
+    TokenExtractor.new.extract(request.headers['Token'])
+  end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,8 +60,12 @@ class ApplicationController < ActionController::API
   private
 
   def authenticate_request
+    # TODO 아래 로직의 책임을 적절한 객체에게 위임하도록 추후 수정
     token = TokenExtractor.new.extract(request.headers[AUTHORIZATION_HEADER])
-    TokenParser.new.parse(token)
+    result = TokenParser.new.parse(token)
+    user = User.find(id: result['user_id'])
+  rescue ActiveRecord::RecordNotFound
+    raise Exceptions::NotFound, "존재하지 않는 회원입니다" if user.nil?
   end
 
 end

--- a/app/controllers/taxi_requests_controller.rb
+++ b/app/controllers/taxi_requests_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class TaxiRequestsController < ApplicationController
+  before_action :authenticate_request
+
+  def index
+    # 인증 인가 테스트를 위한 골격 구현 코드
+  end
+end

--- a/app/services/authenticate_request_processor.rb
+++ b/app/services/authenticate_request_processor.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class AuthenticateRequestProcessor
+
+  def initialize
+    @parser = TokenParser.new
+    @extractor = TokenExtractor.new
+  end
+
+  def authenticate(payload)
+    result = @parser.parse(@extractor.extract(payload))
+    user = User.find(id: result['user_id'])
+    AuthenticatedUser.new(user.id, user.user_type)
+  rescue ActiveRecord::RecordNotFound
+    raise Exceptions::NotFound, "존재하지 않는 회원입니다" if user.nil?
+  end
+end
+
+class AuthenticatedUser
+
+  attr_reader :id, :user_type
+
+  def initialize(id, user_type)
+    @id = id
+    @user_type = user_type
+  end
+end

--- a/app/services/authenticate_user_provider.rb
+++ b/app/services/authenticate_user_provider.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class AuthenticateUserProvider
+
+  class << self
+    def create(request)
+      ins = new(request)
+    end
+  end
+
+  def initialize(request)
+    @processor = AuthenticateRequestProcessor.new
+    @payload = request.headers[AUTHORIZATION_HEADER]
+  end
+
+  def user
+    return
+  end
+
+  private
+
+  AUTHORIZATION_HEADER = 'Authorization'
+
+  USER_KEY = 'USER_KEY'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,6 @@ Rails.application.routes.draw do
     post :sign_up, path: 'sign-up'
     post :sign_in, path: 'sign-in'
   end
+
+  get '/taxi-requests', to: 'taxi_requests#index'
 end

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ApplicationController', type: :request do
+
+  subject { JSON.parse(response.body) }
+
+  describe '#authenticate_request' do
+
+    context 'HTTP Header에 토큰이 없는 경우,' do
+
+      before { get '/taxi-requests', params: {}, headers: {} }
+
+      it '401 UnAuthorized 예외가 발생한다.' do
+        expect(response).to have_http_status(:unauthorized)
+        expect(subject['message']).to eq '로그인이 필요합니다'
+      end
+    end
+  end
+end

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -9,8 +9,27 @@ RSpec.describe 'ApplicationController', type: :request do
   describe '#authenticate_request' do
 
     context 'HTTP Header에 토큰이 없는 경우,' do
-
       before { get '/taxi-requests', params: {}, headers: {} }
+
+      it '401 UnAuthorized 예외가 발생한다.' do
+        expect(response).to have_http_status(:unauthorized)
+        expect(subject['message']).to eq '로그인이 필요합니다'
+      end
+    end
+
+    context 'HTTP Header에 전달한 토큰의 형식이 잘못된 경우,' do
+      let(:header) { { 'Authorization' => 'Token aaa' } }
+      before { get '/taxi-requests', params: {}, headers: header }
+
+      it '401 UnAuthorized 예외가 발생한다.' do
+        expect(response).to have_http_status(:unauthorized)
+        expect(subject['message']).to eq '로그인이 필요합니다'
+      end
+    end
+
+    context 'HTTP Header에 전달한 토큰이 만료된 경우,' do
+      let(:header) { { 'Authorization' => 'Token eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjo0NjQxMTAzNDU5LCJleHAiOjE2MDk0MzQwMDB9.IDq_o0AvfV9vMZJfnLhNetdiXtxWTwAYpesG-v5fCLw' } }
+      before { get '/taxi-requests', params: {}, headers: header }
 
       it '401 UnAuthorized 예외가 발생한다.' do
         expect(response).to have_http_status(:unauthorized)

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -1,39 +1,43 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'shared_helper'
 
 RSpec.describe 'ApplicationController', type: :request do
 
   subject { JSON.parse(response.body) }
 
   describe '#authenticate_request' do
+    let(:header) {}
+    before { get '/taxi-requests', params: {}, headers: header }
 
     context 'HTTP Header에 토큰이 없는 경우,' do
-      before { get '/taxi-requests', params: {}, headers: {} }
 
-      it '401 UnAuthorized 예외가 발생한다.' do
-        expect(response).to have_http_status(:unauthorized)
-        expect(subject['message']).to eq '로그인이 필요합니다'
-      end
+      it_behaves_like 'UnAuthorized 응답 처리', :request
     end
 
     context 'HTTP Header에 전달한 토큰의 형식이 잘못된 경우,' do
       let(:header) { { 'Authorization' => 'Token aaa' } }
-      before { get '/taxi-requests', params: {}, headers: header }
 
-      it '401 UnAuthorized 예외가 발생한다.' do
-        expect(response).to have_http_status(:unauthorized)
-        expect(subject['message']).to eq '로그인이 필요합니다'
-      end
+      it_behaves_like 'UnAuthorized 응답 처리', :request
     end
 
     context 'HTTP Header에 전달한 토큰이 만료된 경우,' do
       let(:header) { { 'Authorization' => 'Token eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjo0NjQxMTAzNDU5LCJleHAiOjE2MDk0MzQwMDB9.IDq_o0AvfV9vMZJfnLhNetdiXtxWTwAYpesG-v5fCLw' } }
-      before { get '/taxi-requests', params: {}, headers: header }
 
-      it '401 UnAuthorized 예외가 발생한다.' do
-        expect(response).to have_http_status(:unauthorized)
-        expect(subject['message']).to eq '로그인이 필요합니다'
+      it_behaves_like 'UnAuthorized 응답 처리', :request
+    end
+
+    context 'HTTP Header에 전달한 토큰이 정상적이지만,' do
+      let(:user_id) { Faker::Number.number }
+      let(:token) { TokenGenerator.new.generate(user_id:) }
+
+      context '토큰 파싱 후 사용자를 조회 시, 찾을 수 없는 경우,' do
+        let(:header) { { 'Authorization' => "Token #{token}" } }
+
+        it_behaves_like 'Not found 응답 처리', :request do
+          let(:message) { '존재하지 않는 회원입니다' }
+        end
       end
     end
   end

--- a/spec/services/token_parser_spec.rb
+++ b/spec/services/token_parser_spec.rb
@@ -16,6 +16,17 @@ RSpec.describe TokenParser, type: :service do
       end
     end
 
+    context '인자로 전달된 token이 이미 만료된 경우,' do
+      let(:expired_token) { 'eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjo0NjQxMTAzNDU5LCJleHAiOjE2MDk0MzQwMDB9.IDq_o0AvfV9vMZJfnLhNetdiXtxWTwAYpesG-v5fCLw' }
+
+      it '예외가 발생한다.' do
+        sut = described_class.new
+
+        expect { sut.parse(expired_token) }
+          .to raise_error(Exceptions::Unauthorized)
+      end
+    end
+
     context '인자로 전달된 token이 유효한 경우,' do
       let(:user_id) { Faker::Number.number }
 

--- a/spec/shared/response.examples.rb
+++ b/spec/shared/response.examples.rb
@@ -13,6 +13,19 @@ shared_examples 'Bad Request 응답 처리' do |request_method_name|
   end
 end
 
+shared_examples 'Not found 응답 처리' do |request_method_name|
+  describe '응답' do
+    subject { JSON.parse(response.body) }
+
+    before { send request_method_name }
+
+    it do
+      expect(response).to have_http_status(:not_found)
+      expect(subject['message']).to eq(message)
+    end
+  end
+end
+
 shared_examples 'Conflict 응답 처리' do |request_method_name|
   describe '응답' do
     subject { JSON.parse(response.body) }
@@ -22,6 +35,19 @@ shared_examples 'Conflict 응답 처리' do |request_method_name|
     it do
       expect(response).to have_http_status(:conflict)
       expect(subject['message']).to eq(message)
+    end
+  end
+end
+
+shared_examples 'UnAuthorized 응답 처리' do |request_method_name|
+  describe '응답' do
+    subject { JSON.parse(response.body) }
+
+    before { send request_method_name }
+
+    it do
+      expect(response).to have_http_status(:unauthorized)
+      expect(subject['message']).to eq('로그인이 필요합니다')
     end
   end
 end


### PR DESCRIPTION
## 작업 내용 (Content)

- 인증 헤더에 토큰이 주어지지 않은 경우에 대한 구현 및 테스트 추가
- 인증 헤더에 토큰 형식이 잘못된 경우, 토큰이 만료된 경우에 대한 구현 및 테스트 추가
- 인증 헤더에 토큰이 올바르나, 사용자를 찾을 수 없는 경우에 대한 구현 및 테스트 추가

## 링크 (Links)

- [인증 요청 시 잘못된 경우에 대한 검증 논리 구현 및 스펙 추가](https://dramancompany.atlassian.net/browse/API-7334)
- [API 스펙 문서](https://dramancompany.atlassian.net/wiki)
- [개발 문서](https://dramancompany.atlassian.net/wiki)
- [기획 문서](https://dramancompany.atlassian.net/wiki)
- [디자인 문서](https://dramancompany.atlassian.net/wiki)

## 기타 사항 (Etc)

- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등
- Additional information about this PR or any troubles working on this PR.

## Merge 전 필요 작업 (Checklist before merge)

- [ ] 예) XX 테이블 추가, 앱 배포 등
- [ ] eg) Create XX table, Deploy app etc

## 희망 리뷰 완료 일 (Expected due date)

`202X. X. X. Wed`