### PR TITLE
API-7353 배차 요청 수락 API 구현 및 검증

### DIFF
--- a/app/controllers/taxi_requests_controller.rb
+++ b/app/controllers/taxi_requests_controller.rb
@@ -12,6 +12,18 @@ class TaxiRequestsController < ApplicationController
     json_success taxi_requests.map { |request| TaxiRequestSerializer.new(request).serialized_json }
   end
 
+  def accept
+    request = TaxiRequest.find(accept_params[:id])
+    raise Exceptions::Conflict, '수락할 수 없는 배차 요청입니다. 다른 배차 요청을 선택하세요' if request.accepted?
+    raise Exceptions::Forbidden, '기사만 배차 요청을 수락할 수 있습니다' unless current_user.driver?
+
+    request.accepted_by(current_user)
+
+    json_success TaxiRequestSerializer.new(request).serialized_json
+  rescue ActiveRecord::RecordNotFound
+    raise Exceptions::NotFound, '존재하지 않는 배차 요청입니다'
+  end
+
   def create
     pending_request = TaxiRequest.find_by(status: TaxiRequest.statuses[:pending])
     raise Exceptions::Forbidden, '승객만 배차 요청할 수 있습니다' unless current_user.passenger?
@@ -32,5 +44,10 @@ class TaxiRequestsController < ApplicationController
   def create_params
     params.require(:address)
     params.merge(passenger_id: current_user.id).permit(:passenger_id, :address)
+  end
+
+  def accept_params
+    params.require(:id)
+    params.permit(:id)
   end
 end

--- a/app/models/taxi_request.rb
+++ b/app/models/taxi_request.rb
@@ -7,4 +7,8 @@ class TaxiRequest < ApplicationRecord
   validates :address, length: { maximum: 100 }, presence: true
   validates :status, inclusion: { in: TaxiRequest.statuses.keys }
   validates :driver_id, :passenger_id, presence: true
+
+  def accepted_by(user)
+    update!(driver_id: user.id, status: :accepted, accepted_at: Time.current)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,9 @@ Rails.application.routes.draw do
   namespace :users do
     post :sign_up, path: 'sign-up'
     post :sign_in, path: 'sign-in'
-    get :me, path: 'me'
   end
 
   get '/taxi-requests', to: 'taxi_requests#index'
   post '/taxi-requests', to: 'taxi_requests#create'
+  post '/taxi-requests/:id/accept', to: 'taxi_requests#accept'
 end


### PR DESCRIPTION
## 작업 내용 (Content)

- 배차 요청 수락 API 구현
- 인증 정보가 유효하지 않은 경우에 대한 검증 테스트 추가
- 기사가 아닌 유저가 배차 요청을 수락하는 경우에 대한 검증 테스트 추가
- 요청한 배차 정보가 존재하지 않는 경우에 대한 검증 테스트 추가
- 이미 수락된 배차 요청인 경우에 대한 검증 테스트 추가

## 링크 (Links)

- [배차 요청 수락 API 구현 및 검증](https://dramancompany.atlassian.net/browse/API-7353)
- [API 스펙 문서](https://dramancompany.atlassian.net/wiki)
- [개발 문서](https://dramancompany.atlassian.net/wiki)
- [기획 문서](https://dramancompany.atlassian.net/wiki)
- [디자인 문서](https://dramancompany.atlassian.net/wiki)

## 기타 사항 (Etc)

- PR에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등
- Additional information about this PR or any troubles working on this PR.

## Merge 전 필요 작업 (Checklist before merge)

- [ ] 예) XX 테이블 추가, 앱 배포 등
- [ ] eg) Create XX table, Deploy app etc

## 희망 리뷰 완료 일 (Expected due date)

`202X. X. X. Wed`